### PR TITLE
Add Team of Teams to books

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ Also, check out the [Slack Team](https://engmanagers.github.io) associated with 
 * [Engineering Managers Slack Team](http://engmanagers.github.io) - Slack team for new-ish engineering managers.
 
 ## Books
+* [Team of Teams: New Rules of Engagement for a Complex World](https://www.amazon.com/Team-Teams-Rules-Engagement-Complex/dp/0241250838/)
 * [Tim Gunn: The Natty Professor: A Master Class on Mentoring, Motivating, and Making It Work!](https://www.amazon.com/Tim-Gunn-Professor-Mentoring-Motivating/dp/1476780072/)
 
 ## Videos


### PR DESCRIPTION
Adding my suggestion of Team of Teams to the books section. Initially recommended in the #books channel of engineering managers slack.
